### PR TITLE
Legend group

### DIFF
--- a/lightweight_charts/abstract.py
+++ b/lightweight_charts/abstract.py
@@ -423,16 +423,19 @@ class SeriesCommon(Pane):
         return VerticalSpan(self, start_time, end_time, color)
 
 
-class Line(SeriesCommon):
-    def __init__(self, chart, name, color, style, width, price_line, price_label, price_scale_id=None, crosshair_marker=True):
 
+class Line(SeriesCommon):
+    def __init__(self, chart, name, color, style, width, price_line, price_label, group, price_scale_id=None, crosshair_marker=True):
         super().__init__(chart, name)
         self.color = color
+        self.group = group  # Store group for potential internal use
 
+        # Pass group as part of the options if createLineSeries handles removing it
         self.run_script(f'''
             {self.id} = {self._chart.id}.createLineSeries(
                 "{name}",
                 {{
+                    group:  '{group}',
                     color: '{color}',
                     lineStyle: {as_enum(style, LINE_STYLE)},
                     lineWidth: {width},
@@ -832,16 +835,18 @@ class AbstractChart(Candlestick, Pane):
         """
         self.run_script(f'{self.id}.chart.timeScale().fitContent()')
 
-    def create_line(
+  def create_line(
             self, name: str = '', color: str = 'rgba(214, 237, 255, 0.6)',
             style: LINE_STYLE = 'solid', width: int = 2,
-            price_line: bool = True, price_label: bool = True, price_scale_id: Optional[str] = None
+            price_line: bool = True, price_label: bool = True, group: str = '',
+            price_scale_id: Optional[str] =None
     ) -> Line:
         """
         Creates and returns a Line object.
         """
-        self._lines.append(Line(self, name, color, style, width, price_line, price_label, price_scale_id))
+        self._lines.append(Line(self, name, color, style, width, price_line, price_label, group, price_scale_id ))
         return self._lines[-1]
+
 
     def create_histogram(
             self, name: str = '', color: str = 'rgba(214, 237, 255, 0.6)',
@@ -854,6 +859,7 @@ class AbstractChart(Candlestick, Pane):
         return Histogram(
             self, name, color, price_line, price_label,
             scale_margin_top, scale_margin_bottom)
+
     
     def create_area(
             self, name: str = '', top_color: str ='rgba(0, 100, 0, 0.5)',
@@ -868,6 +874,8 @@ class AbstractChart(Candlestick, Pane):
                                 width, price_line, price_label, price_scale_id))
     
         return self._lines[-1]
+
+        
     def create_bar(
             self, name: str = '', up_color: str = '#26a69a', down_color: str = '#ef5350',
             open_visible: bool = True, thin_bars: bool = True,

--- a/src/general/legend.ts
+++ b/src/general/legend.ts
@@ -1,20 +1,63 @@
 import { ISeriesApi, LineData, Logical, MouseEventParams, PriceFormatBuiltIn, SeriesType } from "lightweight-charts";
 import { Handler } from "./handler";
 
-
+// Interfaces for the legend elements
 interface LineElement {
     name: string;
     div: HTMLDivElement;
     row: HTMLDivElement;
-    toggle: HTMLDivElement,
-    series: ISeriesApi<SeriesType>,
+    toggle: HTMLDivElement;
+    series: ISeriesApi<SeriesType>;
     solid: string;
 }
 
+interface LegendGroup {
+    name: string;
+    seriesList: ISeriesApi<SeriesType>[];
+    div: HTMLDivElement;
+    row: HTMLDivElement;
+    toggle: HTMLDivElement;
+    solidColors: string[];
+    names: string[];
+}
+// Define the SVG path data
+const openEye = `
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="16" viewBox="0 0 24 24">
+    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:#FFF;stroke-opacity:1;stroke-miterlimit:4;" 
+          d="M 21.998437 12 C 21.998437 12 18.998437 18 12 18 
+             C 5.001562 18 2.001562 12 2.001562 12 
+             C 2.001562 12 5.001562 6 12 6 
+             C 18.998437 6 21.998437 12 21.998437 12 Z" />
+    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:#FFF;stroke-opacity:1;stroke-miterlimit:4;" 
+          d="M 15 12 
+             C 15 13.654687 13.654687 15 12 15 
+             C 10.345312 15 9 13.654687 9 12 
+             C 9 10.345312 10.345312 9 12 9 
+             C 13.654687 9 15 10.345312 15 12 Z" />
+</svg>
+`;
+
+const closedEye = `
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="16" viewBox="0 0 24 24">
+    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:#FFF;stroke-opacity:1;stroke-miterlimit:4;" 
+          d="M 3 3 L 21 21" />
+    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:#FFF;stroke-opacity:1;stroke-miterlimit:4;" 
+          d="M 21.998437 12 
+             C 21.998437 12 18.998437 18 12 18 
+             C 5.001562 18 2.001562 12 2.001562 12 
+             C 2.001562 12 5.001562 6 12 6 
+             C 14.211 6 16.106 6.897 17.7 8.1" />
+    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:#FFF;stroke-opacity:1;stroke-miterlimit:4;" 
+          d="M 9.9 9.9 
+             C 9.367 10.434 9 11.178 9 12 
+             C 9 13.654687 10.345312 15 12 15 
+             C 12.822 15 13.566 14.633 14.1 14.1" />
+</svg>
+`;
 export class Legend {
     private handler: Handler;
     public div: HTMLDivElement;
-    public seriesContainer: HTMLDivElement
+    public seriesContainer: HTMLDivElement;
 
     private ohlcEnabled: boolean = false;
     private percentEnabled: boolean = false;
@@ -24,132 +67,157 @@ export class Legend {
     private text: HTMLSpanElement;
     private candle: HTMLDivElement;
     public _lines: LineElement[] = [];
-
+    public _groups: LegendGroup[] = [];
 
     constructor(handler: Handler) {
-        this.legendHandler = this.legendHandler.bind(this)
-
         this.handler = handler;
-        this.ohlcEnabled = false;
-        this.percentEnabled = false
-        this.linesEnabled = false
-        this.colorBasedOnCandle = false
-
         this.div = document.createElement('div');
-        this.div.classList.add("legend")
-        this.div.style.maxWidth = `${(handler.scale.width * 100) - 8}vw`
-        this.div.style.display = 'none';
+        this.div.classList.add("legend");
+        this.seriesContainer = document.createElement("div");
+        this.text = document.createElement('span');
+        this.candle = document.createElement('div');
         
+        this.setupLegend();
+        this.legendHandler = this.legendHandler.bind(this);
+        handler.chart.subscribeCrosshairMove(this.legendHandler);
+    }
+
+    private setupLegend() {
+        this.div.style.maxWidth = `${(this.handler.scale.width * 100) - 8}vw`;
+        this.div.style.display = 'none';
+
         const seriesWrapper = document.createElement('div');
         seriesWrapper.style.display = 'flex';
         seriesWrapper.style.flexDirection = 'row';
-        this.seriesContainer = document.createElement("div");
+
         this.seriesContainer.classList.add("series-container");
+        this.text.style.lineHeight = '1.8';
 
-        this.text = document.createElement('span')
-        this.text.style.lineHeight = '1.8'
-        this.candle = document.createElement('div')
-        
         seriesWrapper.appendChild(this.seriesContainer);
-        this.div.appendChild(this.text)
-        this.div.appendChild(this.candle)
-        this.div.appendChild(seriesWrapper)
-        handler.div.appendChild(this.div)
-
-        // this.makeSeriesRows(handler);
-
-        handler.chart.subscribeCrosshairMove(this.legendHandler)
+        this.div.appendChild(this.text);
+        this.div.appendChild(this.candle);
+        this.div.appendChild(seriesWrapper);
+        this.handler.div.appendChild(this.div);
     }
 
-    toJSON() {
-        // Exclude the chart attribute from serialization
-        const {_lines, handler, ...serialized} = this;
-        return serialized;
+    legendItemFormat(num: number, decimal: number) {
+        return num.toFixed(decimal).toString().padStart(8, ' ');
     }
-
-    // makeSeriesRows(handler: Handler) {
-    //     if (this.linesEnabled) handler._seriesList.forEach(s => this.makeSeriesRow(s))
-    // }
-
-    makeSeriesRow(name: string, series: ISeriesApi<SeriesType>) {
-        const strokeColor = '#FFF';
-        let openEye = `
-    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:${strokeColor};stroke-opacity:1;stroke-miterlimit:4;" d="M 21.998437 12 C 21.998437 12 18.998437 18 12 18 C 5.001562 18 2.001562 12 2.001562 12 C 2.001562 12 5.001562 6 12 6 C 18.998437 6 21.998437 12 21.998437 12 Z M 21.998437 12 " transform="matrix(0.833333,0,0,0.833333,0,0)"/>
-    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:${strokeColor};stroke-opacity:1;stroke-miterlimit:4;" d="M 15 12 C 15 13.654687 13.654687 15 12 15 C 10.345312 15 9 13.654687 9 12 C 9 10.345312 10.345312 9 12 9 C 13.654687 9 15 10.345312 15 12 Z M 15 12 " transform="matrix(0.833333,0,0,0.833333,0,0)"/>\`
-    `
-        let closedEye = `
-    <path style="fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke:${strokeColor};stroke-opacity:1;stroke-miterlimit:4;" d="M 20.001562 9 C 20.001562 9 19.678125 9.665625 18.998437 10.514062 M 12 14.001562 C 10.392187 14.001562 9.046875 13.589062 7.95 12.998437 M 12 14.001562 C 13.607812 14.001562 14.953125 13.589062 16.05 12.998437 M 12 14.001562 L 12 17.498437 M 3.998437 9 C 3.998437 9 4.354687 9.735937 5.104687 10.645312 M 7.95 12.998437 L 5.001562 15.998437 M 7.95 12.998437 C 6.689062 12.328125 5.751562 11.423437 5.104687 10.645312 M 16.05 12.998437 L 18.501562 15.998437 M 16.05 12.998437 C 17.38125 12.290625 18.351562 11.320312 18.998437 10.514062 M 5.104687 10.645312 L 2.001562 12 M 18.998437 10.514062 L 21.998437 12 " transform="matrix(0.833333,0,0,0.833333,0,0)"/>
-    `
-
-        let row = document.createElement('div')
-        row.style.display = 'flex'
-        row.style.alignItems = 'center'
-        let div = document.createElement('div')
-        let toggle = document.createElement('div')
-        toggle.classList.add('legend-toggle-switch');
-
-
-        let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-        svg.setAttribute("width", "22");
-        svg.setAttribute("height", "16");
-
-        let group = document.createElementNS("http://www.w3.org/2000/svg", "g");
-        group.innerHTML = openEye
-
-        let on = true
-        toggle.addEventListener('click', () => {
-            if (on) {
-                on = false
-                group.innerHTML = closedEye
-                series.applyOptions({
-                    visible: false
-                })
-            } else {
-                on = true
-                series.applyOptions({
-                    visible: true
-                })
-                group.innerHTML = openEye
-            }
-        })
-
-        svg.appendChild(group)
-        toggle.appendChild(svg);
-        row.appendChild(div)
-        row.appendChild(toggle)
-        this.seriesContainer.appendChild(row)
-
-        const color = series.options().color;
-        this._lines.push({
-            name: name,
-            div: div,
-            row: row,
-            toggle: toggle,
-            series: series,
-            solid: color.startsWith('rgba') ? color.replace(/[^,]+(?=\))/, '1') : color
-        });
-    }
-
-    legendItemFormat(num: number, decimal: number) { return num.toFixed(decimal).toString().padStart(8, ' ') }
 
     shorthandFormat(num: number) {
-        const absNum = Math.abs(num)
-        if (absNum >= 1000000) {
-            return (num / 1000000).toFixed(1) + 'M';
-        } else if (absNum >= 1000) {
-            return (num / 1000).toFixed(1) + 'K';
-        }
-        return num.toString().padStart(8, ' ');
+        const absNum = Math.abs(num);
+        return absNum >= 1000000 ? (num / 1000000).toFixed(1) + 'M' :
+               absNum >= 1000 ? (num / 1000).toFixed(1) + 'K' :
+               num.toString().padStart(8, ' ');
     }
 
-    legendHandler(param: MouseEventParams, usingPoint= false) {
-        if (!this.ohlcEnabled && !this.linesEnabled && !this.percentEnabled) return;
-        const options: any = this.handler.series.options()
+    makeSeriesRow(name: string, series: ISeriesApi<SeriesType>): HTMLDivElement {
+        const row = document.createElement('div');
+        row.style.display = 'flex';
+        row.style.alignItems = 'center';
+    
+        const div = document.createElement('div');
+        div.innerText = name;
+    
+        const toggle = document.createElement('div');
+        toggle.classList.add('legend-toggle-switch');
+    
+        const color = (series.options() as any).color || 'rgba(255,0,0,1)'; // Use a default color
+        const solidColor = color.startsWith('rgba') ? color.replace(/[^,]+(?=\))/, '1') : color;
+    
+        const onIcon = this.createSvgIcon(openEye);
+        const offIcon = this.createSvgIcon(closedEye);
+        toggle.appendChild(onIcon.cloneNode(true)); // Clone nodes to avoid duplication
 
+        let visible = true;
+        toggle.addEventListener('click', () => {
+            visible = !visible;
+            series.applyOptions({ visible });
+            toggle.innerHTML = ''; // Clear current icon
+            toggle.appendChild(visible ? onIcon.cloneNode(true) : offIcon.cloneNode(true));
+        });
+    
+        row.appendChild(div);
+        row.appendChild(toggle);
+    
+        this._lines.push({
+            name,
+            div,
+            row,
+            toggle,
+            series,
+            solid: solidColor,
+        });
+        this.seriesContainer.appendChild(row);
+
+        return row;
+    }
+    makeSeriesGroup(groupName: string, names: string[], seriesList: ISeriesApi<SeriesType>[], solidColors: string[]) {
+        const row = document.createElement('div');
+        row.style.display = 'flex';
+        row.style.alignItems = 'center';
+    
+        const div = document.createElement('div');
+        div.style.color = '#FFF'; // Keep group name text in white
+        div.innerText = `${groupName}:`;
+    
+        const toggle = document.createElement('div');
+        toggle.classList.add('legend-toggle-switch');
+    
+        const onIcon = this.createSvgIcon(openEye);
+        const offIcon = this.createSvgIcon(closedEye);
+        toggle.appendChild(onIcon.cloneNode(true));  // Default to visible
+    
+        let visible = true;
+        toggle.addEventListener('click', () => {
+            visible = !visible;
+            seriesList.forEach(series => series.applyOptions({ visible }));
+            toggle.innerHTML = '';  // Clear toggle before appending new icon
+            toggle.appendChild(visible ? onIcon.cloneNode(true) : offIcon.cloneNode(true));
+        });
+    
+        // Build the legend text with only colored squares and regular-weight line names
+        let legendText = `<span style="font-size: 1em; color: #FFF;">${groupName}:</span>`;
+        names.forEach((name, index) => {
+            const color = solidColors[index];
+            legendText += ` <span style="color: ${color};">▨</span> <span style="color: white; font-size: 1em; font-weight: normal;">${name}: -</span>`;
+        });
+    
+        div.innerHTML = legendText; // Set HTML content to maintain colored squares and regular font for line names
+    
+        this._groups.push({
+            name: groupName,
+            seriesList,
+            div,
+            row,
+            toggle,
+            solidColors,
+            names,
+        });
+    
+        row.appendChild(div);
+        row.appendChild(toggle);
+        this.seriesContainer.appendChild(row);
+        return row;
+    }
+    
+
+    private createSvgIcon(svgContent: string): SVGElement {
+        const tempContainer = document.createElement('div');
+        tempContainer.innerHTML = svgContent.trim();
+        const svgElement = tempContainer.querySelector('svg');
+        return svgElement as SVGElement;
+    }
+    
+
+    legendHandler(param: MouseEventParams, usingPoint = false) {
+        if (!this.ohlcEnabled && !this.linesEnabled && !this.percentEnabled) return;
+
+        const options: any = this.handler.series.options();
         if (!param.time) {
-            this.candle.style.color = 'transparent'
-            this.candle.innerHTML = this.candle.innerHTML.replace(options['upColor'], '').replace(options['downColor'], '')
-            return
+            this.candle.style.color = 'transparent';
+            this.candle.innerHTML = this.candle.innerHTML.replace(options['upColor'], '').replace(options['downColor'], '');
+            return;
         }
 
         let data: any;
@@ -157,76 +225,90 @@ export class Legend {
 
         if (usingPoint) {
             const timeScale = this.handler.chart.timeScale();
-            let coordinate = timeScale.timeToCoordinate(param.time)
-            if (coordinate)
-            logical = timeScale.coordinateToLogical(coordinate.valueOf())
-            if (logical)
-            data = this.handler.series.dataByIndex(logical.valueOf())
-        }
-        else {
+            const coordinate = timeScale.timeToCoordinate(param.time);
+            if (coordinate) logical = timeScale.coordinateToLogical(coordinate.valueOf());
+            if (logical) data = this.handler.series.dataByIndex(logical.valueOf());
+        } else {
             data = param.seriesData.get(this.handler.series);
         }
 
-        this.candle.style.color = ''
-        let str = '<span style="line-height: 1.8;">'
+        let str = '<span style="line-height: 1.8;">';
         if (data) {
+            // OHLC Data
             if (this.ohlcEnabled) {
-                str += `O ${this.legendItemFormat(data.open, this.handler.precision)} `
-                str += `| H ${this.legendItemFormat(data.high, this.handler.precision)} `
-                str += `| L ${this.legendItemFormat(data.low, this.handler.precision)} `
-                str += `| C ${this.legendItemFormat(data.close, this.handler.precision)} `
+                str += `O ${this.legendItemFormat(data.open, this.handler.precision)} `;
+                str += `| H ${this.legendItemFormat(data.high, this.handler.precision)} `;
+                str += `| L ${this.legendItemFormat(data.low, this.handler.precision)} `;
+                str += `| C ${this.legendItemFormat(data.close, this.handler.precision)} `;
             }
 
+            // Percentage Movement
             if (this.percentEnabled) {
-                let percentMove = ((data.close - data.open) / data.open) * 100
-                let color = percentMove > 0 ? options['upColor'] : options['downColor']
-                let percentStr = `${percentMove >= 0 ? '+' : ''}${percentMove.toFixed(2)} %`
-
-                if (this.colorBasedOnCandle) {
-                    str += `| <span style="color: ${color};">${percentStr}</span>`
-                } else {
-                    str += '| ' + percentStr
-                }
-            }
-
-            if (this.handler.volumeSeries) {
-                let volumeData: any;
-                if (logical) {
-                    volumeData = this.handler.volumeSeries.dataByIndex(logical)
-                }
-                else {
-                    volumeData = param.seriesData.get(this.handler.volumeSeries)
-                }
-                if (volumeData) {
-                    str += this.ohlcEnabled ? `<br>V ${this.shorthandFormat(volumeData.value)}` : ''
-                }
+                const percentMove = ((data.close - data.open) / data.open) * 100;
+                const color = percentMove > 0 ? options['upColor'] : options['downColor'];
+                const percentStr = `${percentMove >= 0 ? '+' : ''}${percentMove.toFixed(2)} %`;
+                str += this.colorBasedOnCandle ? `| <span style="color: ${color};">${percentStr}</span>` : `| ${percentStr}`;
             }
         }
-        this.candle.innerHTML = str + '</span>'
+        this.candle.innerHTML = str + '</span>';
 
-        this._lines.forEach((e) => {
+        this.updateGroupLegend(param, logical, usingPoint);
+        this.updateSeriesLegend(param, logical, usingPoint);
+    }
+
+    private updateGroupLegend(param: MouseEventParams, logical: Logical | null, usingPoint: boolean) {
+        this._groups.forEach((group) => {
             if (!this.linesEnabled) {
-                e.row.style.display = 'none'
-                return
+                group.row.style.display = 'none';
+                return;
             }
-            e.row.style.display = 'flex'
+            group.row.style.display = 'flex';
 
-            let data
-            if (usingPoint && logical) {
-                data = e.series.dataByIndex(logical) as LineData
+            let legendText = `<span style="font-weight: bold;">${group.name}:</span>`;
+            group.seriesList.forEach((series, index) => {
+                const data = usingPoint && logical
+                    ? series.dataByIndex(logical) as LineData
+                    : param.seriesData.get(series) as LineData;
+
+                if (!data?.value) return;
+
+                const priceFormat = series.options().priceFormat;
+                const price = 'precision' in priceFormat
+                    ? this.legendItemFormat(data.value, (priceFormat as PriceFormatBuiltIn).precision)
+                    : this.legendItemFormat(data.value, 2); // Default precision
+            
+                const color = group.solidColors ? group.solidColors[index] : 'inherit';
+                const name = group.names[index];
+            
+                // Include `price` in legendText
+                legendText += ` <span style="color: ${color};">▦</span> <span style="color: white;">${name}: ${price}</span>`;
+            });
+
+            group.div.innerHTML = legendText;
+        });
+    }
+    private updateSeriesLegend(param: MouseEventParams, logical: Logical | null, usingPoint: boolean) {
+        this._lines.forEach((line) => {
+            if (!this.linesEnabled) {
+                line.row.style.display = 'none';
+                return;
             }
-            else {
-                data = param.seriesData.get(e.series) as LineData
-            }
-            if (!data?.value) return;
-            let price;
-            if (e.series.seriesType() == 'Histogram') {
-                price = this.shorthandFormat(data.value)
+            line.row.style.display = 'flex';
+
+            const data = usingPoint && logical
+                ? line.series.dataByIndex(logical) as LineData
+                : param.seriesData.get(line.series) as LineData;
+
+            if (data?.value !== undefined) {
+                const priceFormat = line.series.options().priceFormat as PriceFormatBuiltIn;
+                const price = 'precision' in priceFormat
+                    ? this.legendItemFormat(data.value, priceFormat.precision)
+                    : this.legendItemFormat(data.value, 2);
+
+                line.div.innerHTML = `<span style="color: ${line.solid};">▨</span> ${line.name}: ${price}`;
             } else {
-                const format = e.series.options().priceFormat as PriceFormatBuiltIn
-                price = this.legendItemFormat(data.value, format.precision)   // couldn't this just be line.options().precision?
+                line.div.innerHTML = `${line.name}: -`;
             }
-            e.div.innerHTML = `<span style="color: ${e.solid};">▨</span>    ${e.name} : ${price}`
-        })
+        });
     }
 }


### PR DESCRIPTION
Add functionality to group lines under a single legend item, following example shown by @esteban2006 in 
issue #452 :  (https://github.com/louisnw01/lightweight-charts-python/issues/452#issuecomment-2355647342)


![image](https://github.com/user-attachments/assets/de0b8ceb-8e4a-4d1f-8ca1-0341670c4be6)
`import pandas as pd
import lightweight_charts_
import time

if __name__ == '__main__':
    # Load OHLCV data
    df = pd.read_csv('./ohlcv.csv')
    
    # Calculate SMAs using rolling method
    df['line1'] = df['close'].rolling(window=10, min_periods=1).mean()
    df['line2'] = df['close'].rolling(window=20, min_periods=1).mean()
    df['line3'] = df['close'].rolling(window=30, min_periods=1).mean()

    chart = lightweight_charts.Chart(inner_width=1, inner_height=1, position='left', debug=True)
    chart.legend(True,font_size=12)


    # Prepare SMA data for MultiLine
    # Correct way to create the DataFrames for each SMA
    data1 = pd.DataFrame({'time': df['time'], 'line1':  df['line1']})
    data2 = pd.DataFrame({'time': df['time'], 'line2':  df['line2']})
    data3 = pd.DataFrame({'time': df['time'], 'line3':  df['line3']})

    # Create MultiLine instance and set initial SMA data
    line1 = chart.create_line('line1',color='#ff0000',group='Group')
    line2 = chart.create_line('line2',color='#acfb00',group='Group')
    line3 = chart.create_line('line3',color='#ffffff')
    

    line1.set(data1)
    line2.set(data2) 
    line3.set(data3)
    # Display the chart
    chart.show(block=True)
`