### PR TITLE
Potential fix for code scanning alert no. 59: Prototype-polluting function

### DIFF
--- a/src/helpers/series.ts
+++ b/src/helpers/series.ts
@@ -950,6 +950,9 @@ function setOptionByPath(target: ISeriesApi<SeriesType>, path: string, value: an
   const keys = path.split(".");
   let obj: any = currentOptions; // cast to any so we can index by string
   for (let i = 0; i < keys.length - 1; i++) {
+    if (keys[i] === "__proto__" || keys[i] === "constructor") {
+      continue;
+    }
     if (!(keys[i] in obj)) {
       obj[keys[i]] = {};
     }


### PR DESCRIPTION
Potential fix for [https://github.com/EsIstJosh/lightweight-charts-python/security/code-scanning/59](https://github.com/EsIstJosh/lightweight-charts-python/security/code-scanning/59)

To fix the problem, we need to ensure that the `setOptionByPath` function does not allow prototype pollution. This can be achieved by blocking the `__proto__` and `constructor` properties from being assigned. We will add a check to skip these properties during the assignment process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
